### PR TITLE
🐛fix(nvim-web-icons): Adds 3º fallback mechanism

### DIFF
--- a/lua/heirline-components/core/utils.lua
+++ b/lua/heirline-components/core/utils.lua
@@ -182,9 +182,16 @@ function M.icon_provider(bufnr)
   local devicons_avail, devicons = pcall(require, "nvim-web-devicons")
   if devicons_avail then
     cached_icon_provider = function(_bufname, _filetype, _buftype)
-      local icon, color = devicons.get_icon_color(_bufname)
-      if not color then
-        icon, color = devicons.get_icon_color_by_filetype(_filetype, { default = _buftype == "" })
+      -- get the icon → by bufname
+      local ok, icon, color = pcall(devicons.get_icon_color, _bufname)
+      if not ok or not color then
+        -- fallback to → attempt by filetype
+        ok, icon, color = pcall(devicons.get_icon_color_by_filetype, _filetype, { default = _buftype == "" })
+        if not ok or not color then
+          -- fallback to → default
+          local default = devicons.get_default_icon()
+          icon, color = default.icon, default.color
+        end
       end
       return icon, color
     end


### PR DESCRIPTION
to `default icon` in case an icon can't be found by bufname nor filetype.