### PR TITLE
fix(lsp): fix possible nil value in progress handler

### DIFF
--- a/lua/heirline-components/core/init.lua
+++ b/lua/heirline-components/core/init.lua
@@ -316,7 +316,7 @@ function M.lsp_progress()
   vim.lsp.handlers["$/progress"] = function(_, msg, info)
     local progress, id = lsp.progress, ("%s.%s"):format(info.client_id, msg.token)
     progress[id] = progress[id] and utils.extend_tbl(progress[id], msg.value) or msg.value
-    if progress[id].kind == "end" then
+    if not progress[id] == nil and progress[id].kind == "end" then
       vim.defer_fn(function()
         progress[id] = nil
         utils.trigger_event("User HeirlineComponentsUpdateLspProgress")

--- a/lua/heirline-components/core/init.lua
+++ b/lua/heirline-components/core/init.lua
@@ -316,7 +316,7 @@ function M.lsp_progress()
   vim.lsp.handlers["$/progress"] = function(_, msg, info)
     local progress, id = lsp.progress, ("%s.%s"):format(info.client_id, msg.token)
     progress[id] = progress[id] and utils.extend_tbl(progress[id], msg.value) or msg.value
-    if not progress[id] == nil and progress[id].kind == "end" then
+    if progress[id] and progress[id].kind == "end" then
       vim.defer_fn(function()
         progress[id] = nil
         utils.trigger_event("User HeirlineComponentsUpdateLspProgress")


### PR DESCRIPTION
When I edit a c# project whilst using the [roslyn-lsp](https://github.com/seblj/roslyn.nvim)
I sometimes get flooded with nil errors.

```
vim.schedule callback: ...ne-components.nvim/lua/heirline-components/core/init
.lua:319: attempt to index a nil value                                        
stack traceback:                                                              
        ...ne-components.nvim/lua/heirline-components/core/init.lua:319: in fu
nction 'handler'                                                              
        /usr/share/nvim/runtime/lua/vim/lsp/client.lua:1172: in function '_not
ification'                                                                    
        /usr/share/nvim/runtime/lua/vim/lsp/client.lua:447: in function ''    
        vim/_editor.lua: in function <vim/_editor.lua:0>
```